### PR TITLE
use contactId passed in as a reference to the current contact

### DIFF
--- a/src/main/java/software/aws/connect/LMSExample.java
+++ b/src/main/java/software/aws/connect/LMSExample.java
@@ -25,10 +25,13 @@ public class LMSExample extends KinesisVideoCommon {
     private final OutputStream outputStreamFromCustomer;
     private final OutputStream outputStreamToCustomer;
     private final String fragmentNumber;
+    private final String contactId;
 
+    // constructor with contactId; compare tag with contactId passed in
     public LMSExample(Regions region,
                       String streamName,
                       String fragmentNumber,
+                      String contactId,
                       AWSCredentialsProvider credentialsProvider,
                       OutputStream outputStreamFromCustomer,
                       OutputStream outputStreamToCustomer) throws IOException {
@@ -38,12 +41,23 @@ public class LMSExample extends KinesisVideoCommon {
         this.outputStreamFromCustomer = outputStreamFromCustomer;
         this.outputStreamToCustomer = outputStreamToCustomer;
         this.fragmentNumber = fragmentNumber;
+        this.contactId = contactId;
+    }
+
+    // Constructor without contactId; compare tag with first contactId read from the tag
+    public LMSExample(Regions region,
+                      String streamName,
+                      String fragmentNumber,
+                      AWSCredentialsProvider credentialsProvider,
+                      OutputStream outputStreamFromCustomer,
+                      OutputStream outputStreamToCustomer) throws IOException {
+        this(region, streamName, fragmentNumber, null, credentialsProvider, outputStreamFromCustomer, outputStreamToCustomer);
     }
 
     public void execute() throws InterruptedException, IOException {
         try {
             FragmentMetadataVisitor fragmentMetadataVisitor = FragmentMetadataVisitor.create();
-            LMSTagVisitor lmsTagVisitor = LMSTagVisitor.create();
+            LMSTagVisitor lmsTagVisitor = (contactId != null) ? LMSTagVisitor.create(contactId) : LMSTagVisitor.create();
             LMSDataVisitor lmsDataVisitor = LMSDataVisitor.create(fragmentMetadataVisitor, lmsTagVisitor, outputStreamFromCustomer, outputStreamToCustomer);
             
             //Start a GetMedia worker to read and process data from the Kinesis Video Stream.

--- a/src/main/java/software/aws/connect/LMSTagVisitor.java
+++ b/src/main/java/software/aws/connect/LMSTagVisitor.java
@@ -13,13 +13,20 @@ import com.amazonaws.kinesisvideo.parser.mkv.MkvStartMasterElement;
 public class LMSTagVisitor extends MkvElementVisitor {
     private String tagName;
     private String tagValue;
+    private final String targetContactId;
     private String prevContactId;
     private boolean isDone = false;
 
-    private LMSTagVisitor () {};
+    private LMSTagVisitor (String targetContactId) {
+        this.targetContactId = targetContactId;
+    };
+
+    public static LMSTagVisitor create(String targetContactId) {
+        return new LMSTagVisitor(targetContactId);
+    }
 
     public static LMSTagVisitor create() {
-        return new LMSTagVisitor();
+        return new LMSTagVisitor(null);
     }
 
     @Override
@@ -49,11 +56,18 @@ public class LMSTagVisitor extends MkvElementVisitor {
             System.out.println(String.format("%s=%s", tagName, tagValue));
 
             // Stop processing if we encounter a different contactId
-            if (tagName == "ContactId") {
-                if (prevContactId == null) {
-                    prevContactId = tagValue;
-                } else if (!tagValue.equals(prevContactId)) {
+            if (tagName.equals("ContactId")) {
+                if (targetContactId != null && !tagValue.equals(targetContactId)) {
+                    // compare against target contactId
+                    System.out.println("Found different ContactId: " + tagValue + ", expected: " + targetContactId + ". Stopping processing.");
                     isDone = true;
+                } else {
+                    // if contactId not provided, then compare against previous contactId read from the tag
+                    if (prevContactId == null) {
+                        prevContactId = tagValue;
+                    } else if (!tagValue.equals(prevContactId)) {
+                        isDone = true;
+                    }
                 }
             }
 

--- a/src/test/java/software/aws/connect/LMSTagVisitorTest.java
+++ b/src/test/java/software/aws/connect/LMSTagVisitorTest.java
@@ -67,4 +67,16 @@ public class LMSTagVisitorTest
         lmsTagVisitor.visit(mkvDataElement);
         assertEquals(false, lmsTagVisitor.isDone());
     }
+
+    @Test
+    public void testIsDoneTrueWithTargetContactId() throws MkvElementVisitException
+    {
+        lmsTagVisitor = LMSTagVisitor.create("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
+
+        when(ebmlElementMetaData.getTypeInfo()).thenReturn(TAGNAME).thenReturn(TAGSTRING);
+        when(mkvValue.getVal()).thenReturn("ContactId").thenReturn("yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy");
+        lmsTagVisitor.visit(mkvDataElement);
+        lmsTagVisitor.visit(mkvDataElement);
+        assertEquals(true, lmsTagVisitor.isDone());
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Added support for passing a contact ID during service initialization to ensure KVS stream processing only handles data for the specified contact. This change includes:

- New constructor parameter for contact ID in LMSExample class
- Backward compatibility through overloaded constructors
- Enhanced TagVisitor to compare against a target contact ID rather than just tracking changes

Also added new unit test to cover the new constructor. Tested with Demo file
```
// previous segment with ContactId
Start of segment
AWS_KINESISVIDEO_FRAGMENT_NUMBER=91343852333181615687036039424264311855293931343
AWS_KINESISVIDEO_SERVER_TIMESTAMP=1757629511.368
AWS_KINESISVIDEO_PRODUCER_TIMESTAMP=1757629512.277
ContactId=4016ec77-0dff-422f-b355-619268eae571
...
End of segment

// current segment with different ContactId
// stopped reading in this case
Start of segment
ContactId=d1350205-22ff-429b-8d81-a9d6ca8a5e33
Executor service is shutdown
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
